### PR TITLE
exception when fire location is out of board

### DIFF
--- a/game.py
+++ b/game.py
@@ -88,7 +88,6 @@ class Game:
                 self.h_symbols,
                 self.v_symbols
             )
-            print("status", status)
 
     def get_orient(
         self,
@@ -137,7 +136,6 @@ class Game:
             if len(re.findall('[0-9]+', location)) >= 2:
                 obtained = True
 
-        print("out of while")
         location = location.split(' ')
         self.x = int(location[0])
         self.y = int(location[1])
@@ -168,13 +166,19 @@ class Game:
         """
         # input messsage when CLI input interface is displayed.
         message_ = f"{player_name}, enter the location you want to fire at in the form row col:"
-        obtained = True
-        while obtained:
+        obtained = False
+        while not obtained:
             # location to fire.
             fire_location = input(message_).rstrip().lstrip()
-            if len(re.findall('[0-9]+', fire_location)) == 2:
-                obtained = False
-        fire_location = fire_location.split(' ')
+            # condition for the num of number is 2. EG. '9 9' is OK, '9 9 9' is NG.
+            number_condition = len(re.findall('[0-9]+', fire_location)) == 2
+
+            fire_location = fire_location.split(' ')
+            row_num_condition = int(fire_location[0]) < self.config.row_num
+            col_num_condition = int(fire_location[1]) < self.config.column_num
+            if (number_condition) and (row_num_condition) and (col_num_condition):
+                obtained = True
+
         self.fire_x = int(fire_location[0])
         self.fire_y = int(fire_location[1])
 

--- a/player.py
+++ b/player.py
@@ -44,56 +44,56 @@ class Player:
         self.firing_board = firing_board
         self.left_ships = config.ship_dict.keys()
 
-        def do_fire(
-                self,
-                fire_x: int,
-                fire_y: int,
-                fired_symbol: str
-        ) -> None:
-            """Process when a player did fire
+    def do_fire(
+            self,
+            fire_x: int,
+            fire_y: int,
+            fired_symbol: str
+    ) -> None:
+        """Process when a player did fire
 
-            Args:
-                fire_x (int): x cordinate to fire.
-                fire_y (int): y cordinate to fire.
-                fired_symbol (str): 'X' or 'O', 
-                    respectively expressing missed and hit.
-            """
-            self.firing_board.board.iloc[
-                fire_x,
-                fire_y
-            ] = fired_symbol
+        Args:
+            fire_x (int): x cordinate to fire.
+            fire_y (int): y cordinate to fire.
+            fired_symbol (str): 'X' or 'O', 
+                respectively expressing missed and hit.
+        """
+        self.firing_board.board.iloc[
+            fire_x,
+            fire_y
+        ] = fired_symbol
 
-        def be_fired(self, fire_x, fire_y, fired_symbol) -> None:
-            """Process when a player is fired
+    def be_fired(self, fire_x, fire_y, fired_symbol) -> None:
+        """Process when a player is fired
 
-            Args:
-                fire_x (int): x cordinate to be fired.
-                fire_y (int): y cordinate to be fired.
-                fired_symbol (str): 'X' or 'O', 
-                    respectively expressing missed and hit.
-            """
-            self.placement_board.board.iloc[
-                fire_x,
-                fire_y
-            ] = fired_symbol
+        Args:
+            fire_x (int): x cordinate to be fired.
+            fire_y (int): y cordinate to be fired.
+            fired_symbol (str): 'X' or 'O', 
+                respectively expressing missed and hit.
+        """
+        self.placement_board.board.iloc[
+            fire_x,
+            fire_y
+        ] = fired_symbol
 
-        def get_left_ships(self) -> None:
-            """Method to know non-destryed ships.
+    def get_left_ships(self) -> None:
+        """Method to know non-destryed ships.
 
-            This function computes the left ships in player's board and
-            let you know when entire ship is destroyed.
-            """
+        This function computes the left ships in player's board and
+        let you know when entire ship is destroyed.
+        """
 
-            # get unique symbols in the board
-            all_cells = self.placement_board.board.values.flatten().tolist()
-            left_ships = [
-                cell for cell in all_cells if cell not in ['*', 'X', 'O']]
-            left_ships = np.unique(left_ships)
+        # get unique symbols in the board
+        all_cells = self.placement_board.board.values.flatten().tolist()
+        left_ships = [
+            cell for cell in all_cells if cell not in ['*', 'X', 'O']]
+        left_ships = np.unique(left_ships)
 
-            # Lost ships when comparing previous phase.
-            diff_left_ships = list(set(self.left_ships) - set(left_ships))
+        # Lost ships when comparing previous phase.
+        diff_left_ships = list(set(self.left_ships) - set(left_ships))
 
-            # If there are changes from previous phase, the destroyed ship is announced.
-            if len(diff_left_ships) > 0:
-                print(f"{self.name}'s {diff_left_ships[0]} is destroyed!")
-                self.left_ships = left_ships
+        # If there are changes from previous phase, the destroyed ship is announced.
+        if len(diff_left_ships) > 0:
+            print(f"{self.name}'s {diff_left_ships[0]} is destroyed!")
+            self.left_ships = left_ships


### PR DESCRIPTION
# Content

When fire location is out of board,  let users input again.
Issue: https://github.com/ShinyaYoshida-biomet/battleship-CLI/issues/6

# Example

Specify 10 10 when a board is like below.

```
   0  1  2  3  4  5  6  7  8  9
0  *  *  *  *  *  *  *  *  *  *
1  *  *  *  *  *  *  *  *  *  *
2  *  *  *  *  *  *  *  *  *  *
3  *  *  *  *  *  *  *  *  *  *
4  *  *  *  *  *  *  *  *  *  *
5  *  *  *  *  *  P  *  *  *  *
6  *  *  *  *  *  P  *  *  *  *
7  *  *  *  *  *  *  *  S  S  S
8  *  *  *  *  *  *  *  *  *  *
9  *  *  *  *  *  *  *  *  *  X
```